### PR TITLE
Fix ios crash and set default color

### DIFF
--- a/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
+++ b/android/src/main/java/com/reactnative/googlecast/GoogleCastButtonManager.java
@@ -19,7 +19,7 @@ public class GoogleCastButtonManager
     extends SimpleViewManager<MediaRouteButton> {
 
   public static final String REACT_CLASS = "RNGoogleCastButton";
-  private Integer mColor = null;
+  private Integer mColor = -12829637;
 
   @Override
   public String getName() {

--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -85,7 +85,7 @@ RCT_REMAP_METHOD(getCastDevice,
     if (device == nil) { resolve(nil); }
     else resolve(@{
       @"id": device.deviceID,
-      @"version": device.deviceVersion,
+      @"version": ([device.deviceVersion isKindOfClass:[NSNull class]]? @"" : (device.deviceVersion ? device.deviceVersion : @"")),
       @"name": device.friendlyName,
       @"model": device.modelName,
     });

--- a/ios/RNGoogleCast/RNGoogleCastButtonManager.m
+++ b/ios/RNGoogleCast/RNGoogleCastButtonManager.m
@@ -12,6 +12,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view {
   GCKUICastButton *castButton = [[GCKUICastButton alloc] init];
+  castButton.tintColor = [UIColor colorWithRed:60.0 / 255.0 green:60.0 / 255.0 blue:59.0 / 255.0 alpha:1];
   return castButton;
 }
 


### PR DESCRIPTION
Fix iOS crash when we connect over nearby devices. Devices version is null and it causing crash. 
Also set default color to match app color, because iOS component render default (blue) color on start